### PR TITLE
feat: add horizontal autoscaler

### DIFF
--- a/charts/hermes/Chart.yaml
+++ b/charts/hermes/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: hermes
 description: Pyth cross-chain server
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: v0.1.10

--- a/charts/hermes/README.md
+++ b/charts/hermes/README.md
@@ -1,6 +1,6 @@
 # hermes
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.10](https://img.shields.io/badge/AppVersion-v0.1.10-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.10](https://img.shields.io/badge/AppVersion-v0.1.10-informational?style=flat-square)
 
 Pyth cross-chain server
 
@@ -9,6 +9,10 @@ Pyth cross-chain server
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
+| autoscaling.enabled | bool | `false` |  |
+| autoscaling.maxReplicas | int | `100` |  |
+| autoscaling.minReplicas | int | `1` |  |
+| autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
 | fullnameOverride | string | `""` |  |
 | hermes.logLevel | string | `"warn"` | Hermes log level. Valid values are: trace, debug, info, warn, error |
 | hermes.pythnetHttpEndpoint | string | `nil` | Pythnet Http RPC endpoint. Must be set. Example: http://localhost:8899 |

--- a/charts/hermes/templates/hpa.yaml
+++ b/charts/hermes/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "hermes.fullname" . }}
+  labels:
+    {{- include "hermes.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "hermes.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/hermes/values.yaml
+++ b/charts/hermes/values.yaml
@@ -75,6 +75,13 @@ resources:
     cpu: 1
     memory: 1Gi
 
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
 nodeSelector: {}
 
 tolerations: []


### PR DESCRIPTION
This is the default that `helm create` generates. I excluded it in the past but I think can become quite useful for hermes when there is a high load from users.

Pythnet on the other hand doesn't need it because there is no external load to change its circumstances.