### PR TITLE
feat(hermes): change liveness to use liveness probe

### DIFF
--- a/charts/hermes/Chart.yaml
+++ b/charts/hermes/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: hermes
 description: Pyth cross-chain server
 type: application
-version: 0.3.1
+version: 0.3.2
 appVersion: v0.3.3

--- a/charts/hermes/README.md
+++ b/charts/hermes/README.md
@@ -1,6 +1,6 @@
 # hermes
 
-![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.3.3](https://img.shields.io/badge/AppVersion-v0.3.3-informational?style=flat-square)
+![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.3.3](https://img.shields.io/badge/AppVersion-v0.3.3-informational?style=flat-square)
 
 Pyth cross-chain server
 

--- a/charts/hermes/templates/deployment.yaml
+++ b/charts/hermes/templates/deployment.yaml
@@ -60,7 +60,7 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /ready
+              path: /live
               port: 8080
             initialDelaySeconds: 30
             periodSeconds: 5


### PR DESCRIPTION
We no longer need to restart when the service is not raedy as the dependencies are going to have proper probes and if they fail hermes will reconnect to them.