### PR TITLE
fix(beacon): fix incorrect service definition

### DIFF
--- a/charts/beacon/Chart.yaml
+++ b/charts/beacon/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: beacon
 description: Highly available Wormhole RPC
 type: application
-version: 1.0.1
+version: 1.0.2
 appVersion: v1.1.2

--- a/charts/beacon/README.md
+++ b/charts/beacon/README.md
@@ -1,6 +1,6 @@
 # beacon
 
-![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.1.2](https://img.shields.io/badge/AppVersion-v1.1.2-informational?style=flat-square)
+![Version: 1.0.2](https://img.shields.io/badge/Version-1.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.1.2](https://img.shields.io/badge/AppVersion-v1.1.2-informational?style=flat-square)
 
 Highly available Wormhole RPC
 

--- a/charts/beacon/templates/service.yaml
+++ b/charts/beacon/templates/service.yaml
@@ -17,7 +17,7 @@ spec:
       name: metrics
     - port: {{ .Values.service.wormholeListenPort }}
       targetPort: wormhole-listen
-      protocol: udp
+      protocol: UDP
       name: wormhole-listen
   selector:
     {{- include "beacon.selectorLabels" . | nindent 4 }}


### PR DESCRIPTION
The helm controller is failing to rollout the new version because of this. I don't know why it didn't appear in the past.